### PR TITLE
From orgno to scheme, id and businessIdentifier

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1092,7 +1092,7 @@ components:
           description: The timestamp (ISO-8601) for when the merchant was created.
           format: date-time
           example: "2022-09-02T06:45:25.921251Z"
-        updateddAt:
+        updatedAt:
           type: string
           description: The timestamp (ISO-8601) for when the merchant was updated (if it has been updated).
           format: date-time

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -979,7 +979,7 @@ components:
       type: object
       properties:
         msn:
-          $ref: '#/components/schemas/msn'
+          $ref: '#/components/parameters/msn'
         name:
           type: string
           description: "The sales unit's name"
@@ -1114,7 +1114,7 @@ components:
           format: date-time
           example: "2022-09-02T06:45:25.921251Z"
         countryCode":
-          type: string,
+          type: string
           description: The merchant's country code, ISO 3166-2 (two capital letters).
           pattern: '^[A-Z]{2}$'
           example: "NO"
@@ -1201,7 +1201,7 @@ components:
         - name
       properties:
         msn:
-          $ref: '#/components/schemas/msn'
+          $ref: '#/components/parameters/msn'
         name:
           type: string
           description: The name of the sales unit.

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1136,28 +1136,34 @@ components:
         - city
         - country
       properties:
-        city:
-          type: string
-          example: Oslo
-        country:
-          type: string
-          example: 'NO'
-          pattern: '^[A-Z]{2}$'
-          description: Country code according to ISO 3166-2 (two capital letters).
         id:
           type: string
           format: uuid
-          description: 'Unique ID of the address, always provided in response from Vipps MobilePay.'
+          description: 'Unique ID of the address, always provided in response.'
+          example: 81b83246-5c19-7b94-875b-ea6d1114f099
         lines:
           type: array
-          description: 'Array of addressLines, for example street name, number, etc.'
+          description: 'Array of addressLines, for example street name, number, etc. May be empty if there is no street address.'
           items:
             type: string
+            maxLength: 30
             example: Robert Levins gate 5
         postCode:
           type: string
           description: Postcode of the address in local country format.
+          maxLength: 20
           example: '0154'
+        city:
+          type: string
+          description: The city.
+          maxLength: 30
+          example: Oslo
+        country:
+          type: string
+          description: Country code according to ISO 3166-2 (two capital letters).
+          pattern: '^[A-Z]{2}$'
+          maxLength: 2
+          example: 'NO'
 
     GetMerchantResponse:
       description: Response of a successful get merchant(s) operation

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Vipps MobilePay Management API
-  version: "1.1.1"
+  version: "1.1.2"
   description: |-
     The Management API lets partners and merchants manage their sales units, etc.
     See the [API Guide](https://developer.vippsmobilepay.com/docs/APIs/management-api).
@@ -1276,7 +1276,7 @@ components:
           example: "business:NO:ORG"
         id:
           type: string
-          description: The business identifier.
+          description: The business identifier, typically the organization number.
           pattern: ^\d{9}$
           example: "9876543221"
 
@@ -1288,12 +1288,12 @@ components:
       properties:
         pricePackageId:
           type: string
-          description: The unique id for the price package
+          description: The unique id for the price package in UUID format.
           format: uuid
           example: "8a11afb7-c223-48ed-8ca6-4722b97261aa"
         name:
           type: string
-          description: The price package' name
+          description: The price package's name.
           maxLength: 30
           example: "POS standard"
         description:
@@ -1304,7 +1304,7 @@ components:
         visibleInSignupForm:
           type: boolean
           description: |-
-            An boolean indicating if the price package is visible for merchants to order on their own in our signup forms.
+            An boolean indicating whether the price package is visible for merchants to order on their own in our signup forms.
           example: True
         productType:
           type: string
@@ -1407,13 +1407,10 @@ components:
       name: Merchant-Serial-Number
       in: header
       description: |-
-        The Merchant Serial Number (MSN) is a unique id for the sale unit
-        that this payment is made for.
-        This is a required parameter if you are a partner
-        making payments on behalf of a merchant.
+        The Merchant Serial Number (MSN) is a unique id for the sale unit that this payment is made for.
+        This is a required parameter if you are a partner making payments on behalf of a merchant.
         The partner must use the merchant's MSN (not the partner's MSN).
-        This parameter is optional, and recommended, for regular Vipps
-        merchants making payments for themselves.
+        This parameter is optional, and recommended, for regular Vipps merchants making payments for themselves.
       schema:
         type: string
       example: 123456
@@ -1421,7 +1418,7 @@ components:
     msn:
       name: msn
       in: path
-      description: "MSN ((merchant serial number): The identifier of the sales unit." 
+      description: "MSN (merchant serial number): The identifier of the sales unit." 
       required: true
       schema:
         minLength: 5 
@@ -1433,7 +1430,7 @@ components:
     scheme:
       name: scheme
       in: path
-      description: "The scheme used for identifying a merchant" 
+      description: "The scheme used for identifying a merchant." 
       required: true
       schema:
         type: string
@@ -1441,7 +1438,7 @@ components:
     id:
       name: id
       in: path
-      description: "The id used for identifying a merchant. For Norwegian companies this is the organization number" 
+      description: "The id used for identifying a merchant. For Norwegian companies this is the organization number." 
       required: true
       schema:
         type: string

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Vipps MobilePay Management API
-  version: "1.1.0"
+  version: "1.1.1"
   description: |-
     The Management API lets partners and merchants manage their sales units, etc.
     See the [API Guide](https://developer.vippsmobilepay.com/docs/APIs/management-api).
@@ -261,7 +261,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Problem"
 
-  /management/v1/merchants/{business-identifier}:
+  /management/v1/merchants/{scheme}/{id}:
     get:
       tags:
         - Merchants
@@ -280,15 +280,8 @@ paths:
         - $ref: "#/components/parameters/Vipps-System-Version"
         - $ref: "#/components/parameters/Vipps-System-Plugin-Name"
         - $ref: "#/components/parameters/Vipps-System-Plugin-Version"
-        - name: business-identifier
-          in: path
-          description: The organization number for the merchant
-          required: true
-          schema:
-            minLength: 10
-            maxLength: 30
-            type: string
-            example: "business:NO:ORG/987654321"
+        - $ref: "#/components/parameters/scheme" 
+        - $ref: "#/components/parameters/id" 
       responses:
         "200":
           description: OK
@@ -303,7 +296,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Problem"
 
-  /management/v1/merchants/{business-identifier}/contracts:
+  /management/v1/merchants/{scheme}/{id}/contracts:
     get:
       tags:
         - Merchants
@@ -319,15 +312,8 @@ paths:
         - $ref: "#/components/parameters/Vipps-System-Version"
         - $ref: "#/components/parameters/Vipps-System-Plugin-Name"
         - $ref: "#/components/parameters/Vipps-System-Plugin-Version"
-        - name: business-identifier
-          in: path
-          description: The organization number for the merchant
-          required: true
-          schema:
-            minLength: 10
-            maxLength: 30
-            type: string
-            example: "business:NO:ORG/987654321"
+        - $ref: "#/components/parameters/scheme" 
+        - $ref: "#/components/parameters/id" 
       responses:
         "200":
           description: OK
@@ -342,7 +328,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Problem"
 
-  /management/v1/merchants/{business-identifier}/sales-units:
+  /management/v1/merchants/{scheme}/{id}/sales-units:
     get:
       tags:
         - Merchants
@@ -359,15 +345,8 @@ paths:
         - $ref: "#/components/parameters/Vipps-System-Version"
         - $ref: "#/components/parameters/Vipps-System-Plugin-Name"
         - $ref: "#/components/parameters/Vipps-System-Plugin-Version"
-        - name: business-identifier
-          in: path
-          description: The organization number for the merchant
-          required: true
-          schema:
-            minLength: 10
-            maxLength: 30
-            type: string
-            example: "business:NO:ORG/987654321"
+        - $ref: "#/components/parameters/scheme" 
+        - $ref: "#/components/parameters/id" 
       responses:
         "200":
           description: OK
@@ -1444,3 +1423,20 @@ components:
         pattern: ^\d{5,6}$
         type: string
         example: 123456
+
+    scheme:
+      name: scheme
+      in: path
+      description: "The scheme used for identifying a merchant" 
+      required: true
+      schema:
+        type: string
+        example: "business:NO:ORG"  
+    id:
+      name: id
+      in: path
+      description: "The id used for identifying a merchant. For Norwegian companies this is the organization number" 
+      required: true
+      schema:
+        type: string
+        example: "9876543221"        

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1166,9 +1166,9 @@ components:
       description: List of the merchants a partner has access to
       type: object
       required:
-        - MerchantList  
+        - merchants  
       properties:
-        MerchantList:
+        merchants:
           type: array
           description: List of merchants
           items:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -979,13 +979,7 @@ components:
       type: object
       properties:
         msn:
-          minLength: 5
-          maxLength: 6
-          pattern: ^\d{5,6}$
-          type: string
-          description: Vipps MSN (merchant serial number)
-          example: "123456"
-          x-order: 4
+          $ref: '#/components/schemas/msn'
         name:
           type: string
           description: "The sales unit's name"
@@ -1109,6 +1103,57 @@ components:
             - DEACTIVATED
           default: ACTIVE
           example: ACTIVE  
+        createdAt:
+          type: string
+          description: The timestamp (ISO-8601) for when the merchant was created.
+          format: date-time
+          example: "2022-09-02T06:45:25.921251Z"
+        updateddAt:
+          type: string
+          description: The timestamp (ISO-8601) for when the merchant was updated (if it has been updated).
+          format: date-time
+          example: "2022-09-02T06:45:25.921251Z"
+        countryCode":
+          type: string,
+          description: The merchant's country code, ISO 3166-2 (two capital letters).
+          pattern: '^[A-Z]{2}$'
+          example: "NO"
+        businessAddress:
+          $ref: '#/components/schemas/Address'
+        businesspostlAddress:
+          $ref: '#/components/schemas/Address'          
+
+    Address:
+      title: Address
+      type: object
+      required:
+        - lines
+        - postCode
+        - city
+        - country
+      properties:
+        city:
+          type: string
+          example: Oslo
+        country:
+          type: string
+          example: 'NO'
+          pattern: '^[A-Z]{2}$'
+          description: Country code according to ISO 3166-2 (two capital letters).
+        id:
+          type: string
+          format: uuid
+          description: 'Unique ID of the address, always provided in response from Vipps MobilePay.'
+        lines:
+          type: array
+          description: 'Array of addressLines, for example street name, number, etc.'
+          items:
+            type: string
+            example: Robert Levins gate 5
+        postCode:
+          type: string
+          description: Postcode of the address in local country format.
+          example: '0154'
 
     GetMerchantResponse:
       description: Response of a successful get merchant(s) operation
@@ -1156,12 +1201,7 @@ components:
         - name
       properties:
         msn:
-          type: string
-          description: MSN (Merchant Serial Number), the id of the sales unit.
-          minLength: 5
-          maxLength: 6
-          pattern: ^\d{5,6}$
-          example: "123456"
+          $ref: '#/components/schemas/msn'
         name:
           type: string
           description: The name of the sales unit.

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -239,7 +239,7 @@ paths:
         Status: Idea/proposal.
 
         For partners.
-        Get a (long) list of all orgnos that have one or more sale units registered with the partner making the API call.
+        Get a (long) list of all merchants that have one or more sale units registered with the partner making the API call.
       operationId: getAllMerchants
       parameters:
         - $ref: "#/components/parameters/Merchant-Serial-Number"
@@ -261,7 +261,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Problem"
 
-  /management/v1/merchants/{orgno}:
+  /management/v1/merchants/{business-identifier}:
     get:
       tags:
         - Merchants
@@ -273,23 +273,22 @@ paths:
         **Please note:** There are strict rules for what information Vipps MobilePay is allowed to share with
         a partner, as this requires active consent from the merchant, and the merchant must also
         be able to withdraw the consent.
-      operationId: getMerchantByOrgno
+      operationId: getMerchantBusinessIdentifier
       parameters:
         - $ref: "#/components/parameters/Merchant-Serial-Number"
         - $ref: "#/components/parameters/Vipps-System-Name"
         - $ref: "#/components/parameters/Vipps-System-Version"
         - $ref: "#/components/parameters/Vipps-System-Plugin-Name"
         - $ref: "#/components/parameters/Vipps-System-Plugin-Version"
-        - name: orgno
+        - name: business-identifier
           in: path
           description: The organization number for the merchant
           required: true
           schema:
-            minLength: 9
-            maxLength: 9
-            pattern: ^\d{9}$
+            minLength: 10
+            maxLength: 30
             type: string
-            example: 987654321
+            example: "business:NO:ORG/987654321"
       responses:
         "200":
           description: OK
@@ -304,7 +303,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Problem"
 
-  /management/v1/merchants/{orgno}/contracts:
+  /management/v1/merchants/{business-identifier}/contracts:
     get:
       tags:
         - Merchants
@@ -320,16 +319,15 @@ paths:
         - $ref: "#/components/parameters/Vipps-System-Version"
         - $ref: "#/components/parameters/Vipps-System-Plugin-Name"
         - $ref: "#/components/parameters/Vipps-System-Plugin-Version"
-        - name: orgno
+        - name: business-identifier
           in: path
           description: The organization number for the merchant
           required: true
           schema:
-            maxLength: 9
-            minLength: 9
-            pattern: ^\d{9}$
+            minLength: 10
+            maxLength: 30
             type: string
-            example: 987654321
+            example: "business:NO:ORG/987654321"
       responses:
         "200":
           description: OK
@@ -344,7 +342,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Problem"
 
-  /management/v1/merchants/{orgno}/sales-units:
+  /management/v1/merchants/{business-identifier}/sales-units:
     get:
       tags:
         - Merchants
@@ -361,16 +359,15 @@ paths:
         - $ref: "#/components/parameters/Vipps-System-Version"
         - $ref: "#/components/parameters/Vipps-System-Plugin-Name"
         - $ref: "#/components/parameters/Vipps-System-Plugin-Version"
-        - name: orgno
+        - name: business-identifier
           in: path
           description: The organization number for the merchant
           required: true
           schema:
-            minLength: 9
-            maxLength: 9
-            pattern: ^\d{9}$
+            minLength: 10
+            maxLength: 30
             type: string
-            example: 987654321
+            example: "business:NO:ORG/987654321"
       responses:
         "200":
           description: OK
@@ -1070,7 +1067,7 @@ components:
     Merchant:
       description: A merchant
       required:
-        - orgno
+        - businessIdentifier
         - name
       type: object
       properties:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -612,16 +612,7 @@ components:
             Images not matching the above criteria will not be shown to the merchant in the merchant portal.
             The logo can be edited later on portal.vipps.no.
         settlementAccountNumber:
-          nullable: true
-          type: string
-          pattern: "^[0-9]{11,11}$"
-          minLength: 11
-          maxLength: 11
-          example: "86011117947"
-          description: |-
-            The bank account number belonging to the organisation that will be
-            used for settlement. The bank account must be owned by the
-            merchant. BBAN (not IBAN) format.
+          $ref: '#/components/schemas/bankAccountBBAN'
         pricePackageId:
           type: string
           format: uuid
@@ -905,11 +896,12 @@ components:
           type: string
           description: The status of the PO
           enum:
+            - ACCESSED
             - RECEIVED
             - PROCESSING
             - WAITING_FOR_MERCHANT
             - COMPLETED
-          example: PROCESSING
+          example: ACCESSED
 
     ApiQualityResponse:
       title: API quality response
@@ -979,7 +971,7 @@ components:
       type: object
       properties:
         msn:
-          $ref: '#/components/parameters/msn'
+          $ref: '#/components/schemas/MSN'
         name:
           type: string
           description: "The sales unit's name"
@@ -1082,13 +1074,8 @@ components:
         - name
       type: object
       properties:
-        orgno:
-          type: string
-          description: The organization number for the merchant
-          minLength: 9
-          maxLength: 9
-          pattern: ^\d{9}$
-          example: 987654321
+        businessidentifier:
+          $ref: '#/components/schemas/businessIdentifier'
         name:
           type: string
           description: The name of the merchant
@@ -1122,6 +1109,47 @@ components:
           $ref: '#/components/schemas/Address'
         businesspostlAddress:
           $ref: '#/components/schemas/Address'          
+
+    bankAccountBBAN:
+      title: Bank account in BBAN format. ISO 13616.
+      type: object
+      required:
+        - scheme
+        - id
+      properties:
+        scheme:
+          type: string
+          description: The type of identifier for the bank.
+          minLength: 5
+          maxLength: 20
+          example: "BBAN:NO"
+        id:
+          type: string
+          description: The account number (or id).
+          minLength: 9
+          maxLength: 20
+          pattern: ^\d{9,}$
+          example: "86011117947"
+
+    bankAccountIBAN:
+      title: Bank account in IBAN format. ISO 13616.
+      type: object
+      required:
+        - scheme
+        - id
+      properties:
+        scheme:
+          type: string
+          description: The type of identifier for the bank.
+          minLength: 5
+          maxLength: 20
+          example: "IBAN:NO"
+        id:
+          type: string
+          description: The account number (or id). No whitespace.
+          minLength: 9
+          maxLength: 20
+          example: "NO9386011117947"      
 
     Address:
       title: Address
@@ -1159,7 +1187,7 @@ components:
       description: Response of a successful get merchant(s) operation
       type: object
       properties:
-        data:
+        merchant:
           $ref: '#/components/schemas/Merchant'
     
     GetAllMerchantsResponse:
@@ -1193,6 +1221,14 @@ components:
             description: URL for downloading PDF contract
             example: "https://example.com/contracts/contract-12345.pdf"
 
+    MSN:
+      description: "MSN (merchant serial number): The identifier of the sales unit." 
+      type: string
+      minLength: 5 
+      maxLength: 6
+      pattern: ^\d{5,6}$
+      example: 123456
+
     MsnInfo:
       description: High-level details about a MSN
       type: object
@@ -1201,7 +1237,7 @@ components:
         - name
       properties:
         msn:
-          $ref: '#/components/parameters/msn'
+          $ref: '#/components/schemas/MSN'
         name:
           type: string
           description: The name of the sales unit.
@@ -1215,7 +1251,7 @@ components:
         name:
           type: string
           description: Name of the sales unit.
-          example: ACME Fantastic Fitness DeLuxe
+          example: ACME Fantastic Fitness Deluxe
           maxLength: 50
         salesUnitLogo:
           type: string
@@ -1245,16 +1281,21 @@ components:
       type: object
       description: |-
         Business registration number of the merchant for whom the partner is submitting the product order.
-        Only Norwegian (business:NO:ORG) business registration numbers are allowed for now, but this format supports all countries.
+        Only Norwegian (`business:NO:ORG``) business registration numbers are allowed for now, but this format supports all countries.
       required:
         - scheme
         - id
       properties:
         scheme:
           type: string
+          description: The type of identifier for the business.
+          minLength: 10
+          maxLength: 20
           example: "business:NO:ORG"
         id:
           type: string
+          description: The business identifier.
+          pattern: ^\d{9}$
           example: "9876543221"
 
     PricePackage:
@@ -1395,21 +1436,10 @@ components:
         type: string
       example: 123456
 
-    orgno:
-      name: orgno
-      in: path
-      description: The organization number for the merchant
-      required: true
-      schema:
-        minLength: 9
-        maxLength: 9
-        pattern: ^\d{9}$
-        type: string
-        example: 987654321
     msn:
       name: msn
       in: path
-      description: The Vipps MSN (merchant serial number)
+      description: "MSN ((merchant serial number): The identifier of the sales unit." 
       required: true
       schema:
         minLength: 5 

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Vipps MobilePay Management API
-  version: "1.0.0"
+  version: "1.1.0"
   description: |-
     The Management API lets partners and merchants manage their sales units, etc.
     See the [API Guide](https://developer.vippsmobilepay.com/docs/APIs/management-api).

--- a/management-api-faq.md
+++ b/management-api-faq.md
@@ -102,7 +102,7 @@ environment. See
 
 If you send an invalid request to
 [`POST:/products/orders`](https://developer.vippsmobilepay.com/api/management#tag/Vipps-Product-Orders/operation/orderProduct),
-the pre-fill will _in most cases_ fail with an error message.
+the pre-fill operation will _in most cases_ fail with an error message.
 
 Although we do as much input validation as possible, it is not possible to validate all data, so in some cases the
 pre-fill request will succeed, and the pre-fill URL will lead to an empty product order form.

--- a/management-api-guide.md
+++ b/management-api-guide.md
@@ -19,7 +19,7 @@ We are implementing the most important functionality first, and these endpoints 
    The merchant simply uses a URL to get to the pre-filled product order, checks the data, and submits.
    This ensures that all the data in the form is correctly filled in, and can also "lock" parameters that are normally selectable. Product orders
    that have been pre-filled this way are processed faster, since they are correct and contain all the required information.
-2. [Get the sales units for a merchant by orgno](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-the-sales-units-for-a-merchant-by-orgno):
+2. [Get the sales units for a merchant by business identifier](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-the-sales-units-for-a-merchant-by-business-identifier):
    An easy way to get a list of all the sales units that belong to the specified merchant.  
 3. [Get information about a sales unit](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-information-about-a-sales-unit):
    This endpoint is for retrieving details about one sales unit (MSN), such as
@@ -64,9 +64,9 @@ even without an integration in place.
 | -------- | ----------- | ------ |
 | Merchants: | | |
 | [`GET:/merchants`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getAllMerchants) | [Get all merchants](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-all-merchants). | 💡 Idea/proposal |
-| [`GET:/merchants/{orgno}`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchant) | [Get one merchant by organization number](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-one-merchant-by-organization-number). | 🟡 Available in Q3 |
-| [`GET:/merchants/{orgno}/contracts`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchantContracts) | [Get a merchant's contract(s)](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-a-merchants-contracts). | 💡 Idea/proposal |
-| [`GET:/merchants/{orgno}/sales-units`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchantSalesUnits) | [Get the sales units for a merchant by orgno](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-the-sales-units-for-a-merchant-by-orgno). | ✅ Available |
+| [`GET:/merchants/{businessIdentifier}`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchant) | [Get one merchant by organization number](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-one-merchant-by-organization-number). | 🟡 Available in Q3 |
+| [`GET:/merchants/{businessIdentifier}/contracts`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchantContracts) | [Get a merchant's contract(s)](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-a-merchants-contracts). | 💡 Idea/proposal |
+| [`GET:/merchants/{businessIdentifier}/sales-units`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchantSalesUnits) | [Get the sales units for a merchant by business identifier](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-the-sales-units-for-a-merchant-by-business-identifier). | ✅ Available |
 | Sales units: | | |
 | [`GET:/sales-units`](https://developer.vippsmobilepay.com/api/management/#tag/Sales-units/operation/getAllSalesUnits) | [Get all sales units](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-all-sales-units). | 🟡 Available in Q4 |
 | [`GET:/sales-units/{msn}`](https://developer.vippsmobilepay.com/api/management/#tag/Sales-units/operation/getMsn) | [Get information about a sales unit](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-information-about-a-sales-unit). | ✅ Available |
@@ -87,7 +87,7 @@ Status: 💡 Idea/proposal.
 
 For partners using
 [partner keys](https://developer.vippsmobilepay.com/docs/partner/partner-keys):
-Get a (long) list of all `orgno`s that have one or more sales units registered with the partner making the API call.
+Get a (long) list of all merchants that have one or more sales units registered with the partner making the API call.
 
 [`GET:/management/v1/merchants`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getAllMerchants)
 
@@ -123,7 +123,7 @@ Status: 🟡 Available in Q3.
 
 This endpoint is for retrieving basic information about the merchant:
 
-[`GET:/management/v1/merchants/{orgno}`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchant)
+[`GET:/management/v1/merchants/{businessIdentifier}`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchant)
 
 Response:
 
@@ -176,7 +176,7 @@ Status: 💡 Idea/proposal.
 
 Return a (link to a) PDF.
 
-[`GET:/management/v1/merchants/{orgno}/contracts`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchantContracts)
+[`GET:/management/v1/merchants/{businessIdentifier}/contracts`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchantContracts)
 
 Response:
 
@@ -188,11 +188,11 @@ Response:
 }
 ```
 
-## Get the sales units for a merchant by orgno
+## Get the sales units for a merchant by business identifier
 
 Status: ✅ Available.
 
-[`GET:/management/v1/merchants/{orgno}/sales-units`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchantSalesUnits)
+[`GET:/management/v1/merchants/{businessIdentifier}/sales-units`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchantSalesUnits)
 
 Response:
 
@@ -243,7 +243,7 @@ Response:
 
 It is then possible to use
 [`GET:/management/v1/sales-units/{msn}`](https://developer.vippsmobilepay.com/api/management/#tag/Sales-units/operation/getMsn)
-to get each MSN's details, including the orgno of the merchant it belongs to.
+to get each MSN's details, including the business identifier of the merchant it belongs to.
 
 ## Get information about a sales unit
 
@@ -322,7 +322,7 @@ Response (this improvement is provided for discussions of what we should investi
 }
 ```
 
-The `orgno` is included to make it possible to find out the merchant that is associated with an MSN.
+The `businessIdentifier` is included to make it possible to find out the merchant that is associated with an MSN.
 This is useful when only the MSN is known.
 
 Future versions of the API will _probably_ return more information,
@@ -518,7 +518,7 @@ The user will then automatically be presented with the pre-filled PO.
    checks the details in the PO and submits it.
 6. We process the PO and send both the merchant and partner/merchant who made the pre-fill request an
    email when done. The partner/merchant who made the pre-fill request can also check with the API:
-   [`GET:/management/v1/merchants/{orgno}`](https://developer.vippsmobilepay.com/api/partner#tag/Merchants/operation/getMerchant).
+   [`GET:/management/v1/merchants/{businessIdentifier}`](https://developer.vippsmobilepay.com/api/partner#tag/Merchants/operation/getMerchant).
 
 The most important part of the MA form is the "reelle rettighetshavere"
 ("real rights holders"), meaning the people with direct or direct ownership or
@@ -540,7 +540,7 @@ The merchant has an MA and probably also a Vipps MobilePay product.
    checks the details and submits it.
 4. We process the PO and send both the merchant and partner/merchant who made the pre-fill request an
    email when done. The partner/merchant who made the pre-fill request can also check with the API:
-   [`GET:/management/v1/merchants/{orgno}`](https://developer.vippsmobilepay.com/api/partner#tag/Merchants/operation/getMerchant).
+   [`GET:/management/v1/merchants/{businessIdentifier}`](https://developer.vippsmobilepay.com/api/partner#tag/Merchants/operation/getMerchant).
 
 In the future, we may allow the merchant to change some data pre-filled by the
 partner, but this is not trivial. If the merchant changes any data, the

--- a/management-api-guide.md
+++ b/management-api-guide.md
@@ -15,7 +15,7 @@ as much as possible without needing assistance from us.
 We are implementing the most important functionality first, and these endpoints are available now:
 
 1. [Pre-fill a product order](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#pre-fill-a-product-order):
-   This endpoint allows for "pre-fill" of the product order form on portal.vipps.no. 
+   This endpoint allows for "pre-fill" of the product order form on portal.vipps.no.
    The merchant simply uses a URL to get to the pre-filled product order, checks the data, and submits.
    This ensures that all the data in the form is correctly filled in, and can also "lock" parameters that are normally selectable. Product orders
    that have been pre-filled this way are processed faster, since they are correct and contain all the required information.
@@ -369,7 +369,6 @@ The merchant simply uses the URL to get to the pre-filled product order, checks 
 something needs to be corrected, the merchant must contact the partner to have
 the partner submit a new pre-fill product order with the correct details.
 
-
 <details>
 <summary>Example request</summary>
 <div>
@@ -462,7 +461,6 @@ Response:
 </div>
 </details>
 
-
 ### Processing of the pre-filled product order
 
 When the submitted product order has been processed, an email is sent to both the
@@ -510,7 +508,7 @@ The user will then automatically be presented with the pre-filled PO.
    [portal.vipps.no](https://portal.vipps.no).
 3. The merchant is presented with a page informing them that they need to
    sign an MA before filling in the PO.
-4. The merchant completes, signs and submits the MA.   
+4. The merchant completes, signs and submits the MA.
 5. The merchant re-uses the link or finds the link to the pre-filled PO form on the
    front page on
    [portal.vipps.no](https://portal.vipps.no)
@@ -590,7 +588,7 @@ sequenceDiagram
 
 Status: 💡 Idea/proposal.
 
-For both merchants and partners. 
+For both merchants and partners.
 
 The best way to check the status of a product order is on
 [portal.vipps.no](https://portal.vipps.no).

--- a/management-api-guide.md
+++ b/management-api-guide.md
@@ -123,8 +123,24 @@ Response:
 
 ```json
 {
-  "orgno": 987654321,
-  "name": "ACME Fantastic Fitness"
+   "orgno": 987654321,
+   "name": "ACME Fantastic Fitness",
+   "isActive": true,
+   "createdAt": "2022-09-02T06:45:25.921251Z",
+   "updatedAt": "2023-03-27T13:50:21.750612Z",
+    "countryCode": "NO",
+   "businessAddress": {
+      "line1": "Robert Levins gate 5",
+      "locality": "OSLO",
+      "postalCode": "0154",
+      "countryCode": "NO"
+    },
+    "postalAddress": {
+      "line1": "Postboks 9236 Grønland",
+      "locality": "OSLO",
+      "postalCode": "0134",
+      "countryCode": "NO"
+    }
 }
 ```
 
@@ -132,12 +148,10 @@ Future versions of the API will _probably_ return more information,
 and we will work with our partners to find out what is useful and possible.
 Some candidates:
 
-* Company address
 * Contact information for the main person (depends on GDPR)
 * Contact information for the technical person (depends on GDPR)
 * A list of people with admin rights on [portal.vipps.no](https://portal.vipps.no) (depend on GDPR)
 * Changelog: What was changed when by whom?
-
 
 ## Get a merchant's contract(s)
 

--- a/management-api-guide.md
+++ b/management-api-guide.md
@@ -137,7 +137,7 @@ Response:
     "name": "ACME Fantastic Fitness",
     "status": "ACTIVE",
     "createdAt": "2022-09-02T06:45:25.921251Z",
-    "updateddAt": "2022-09-02T06:45:25.921251Z",
+    "updatedAt": "2022-09-02T06:45:25.921251Z",
     "countryCode\"": "NO",
     "businessAddress": {
       "city": "Oslo",

--- a/management-api-guide.md
+++ b/management-api-guide.md
@@ -64,9 +64,9 @@ even without an integration in place.
 | -------- | ----------- | ------ |
 | Merchants: | | |
 | [`GET:/merchants`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getAllMerchants) | [Get all merchants](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-all-merchants). | 💡 Idea/proposal |
-| [`GET:/merchants/{businessIdentifier}`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchant) | [Get one merchant by business identifier](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-one-merchant-by-business-identifier). | 🟡 Available in Q3 |
-| [`GET:/merchants/{businessIdentifier}/contracts`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchantContracts) | [Get a merchant's contract(s)](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-a-merchants-contracts). | 💡 Idea/proposal |
-| [`GET:/merchants/{businessIdentifier}/sales-units`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchantSalesUnits) | [Get the sales units for a merchant by business identifier](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-the-sales-units-for-a-merchant-by-business-identifier). | ✅ Available |
+| [`GET:/merchants/{{scheme}/{id}`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchant) | [Get one merchant by business identifier](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-one-merchant-by-business-identifier). | 🟡 Available in Q3 |
+| [`GET:/merchants/{scheme}/{id}/contracts`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchantContracts) | [Get a merchant's contract(s)](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-a-merchants-contracts). | 💡 Idea/proposal |
+| [`GET:/merchants/{scheme}/{id}/sales-units`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchantSalesUnits) | [Get the sales units for a merchant by business identifier](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-the-sales-units-for-a-merchant-by-business-identifier). | ✅ Available |
 | Sales units: | | |
 | [`GET:/sales-units`](https://developer.vippsmobilepay.com/api/management/#tag/Sales-units/operation/getAllSalesUnits) | [Get all sales units](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-all-sales-units). | 🟡 Available in Q4 |
 | [`GET:/sales-units/{msn}`](https://developer.vippsmobilepay.com/api/management/#tag/Sales-units/operation/getMsn) | [Get information about a sales unit](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-information-about-a-sales-unit). | ✅ Available |
@@ -123,7 +123,7 @@ Status: 🟡 Available in Q3.
 
 This endpoint is for retrieving basic information about the merchant:
 
-[`GET:/management/v1/merchants/{businessIdentifier}`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchant)
+[`GET:/management/v1/merchants/{scheme}/{id}`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchant)
 
 Response:
 
@@ -176,7 +176,7 @@ Status: 💡 Idea/proposal.
 
 Return a (link to a) PDF.
 
-[`GET:/management/v1/merchants/{businessIdentifier}/contracts`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchantContracts)
+[`GET:/management/v1/merchants/{scheme}/{id}/contracts`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchantContracts)
 
 Response:
 
@@ -192,7 +192,7 @@ Response:
 
 Status: ✅ Available.
 
-[`GET:/management/v1/merchants/{businessIdentifier}/sales-units`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchantSalesUnits)
+[`GET:/management/v1/merchants/{scheme}/{id}/sales-units`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchantSalesUnits)
 
 Response:
 
@@ -518,7 +518,7 @@ The user will then automatically be presented with the pre-filled PO.
    checks the details in the PO and submits it.
 6. We process the PO and send both the merchant and partner/merchant who made the pre-fill request an
    email when done. The partner/merchant who made the pre-fill request can also check with the API:
-   [`GET:/management/v1/merchants/{businessIdentifier}`](https://developer.vippsmobilepay.com/api/partner#tag/Merchants/operation/getMerchant).
+   [`GET:/management/v1/merchants/{scheme}/{id}`](https://developer.vippsmobilepay.com/api/partner#tag/Merchants/operation/getMerchant).
 
 The most important part of the MA form is the "reelle rettighetshavere"
 ("real rights holders"), meaning the people with direct or direct ownership or
@@ -540,7 +540,7 @@ The merchant has an MA and probably also a Vipps MobilePay product.
    checks the details and submits it.
 4. We process the PO and send both the merchant and partner/merchant who made the pre-fill request an
    email when done. The partner/merchant who made the pre-fill request can also check with the API:
-   [`GET:/management/v1/merchants/{businessIdentifier}`](https://developer.vippsmobilepay.com/api/partner#tag/Merchants/operation/getMerchant).
+   [`GET:/management/v1/merchants/{scheme}/{id}`](https://developer.vippsmobilepay.com/api/partner#tag/Merchants/operation/getMerchant).
 
 In the future, we may allow the merchant to change some data pre-filled by the
 partner, but this is not trivial. If the merchant changes any data, the

--- a/management-api-guide.md
+++ b/management-api-guide.md
@@ -97,11 +97,17 @@ Response:
 {
    "merchants":[
       {
-         "orgno": 987654321,
+          "businessIdentifier":{
+            "scheme":"business:NO:ORG",
+            "id":"987654321"
+         },
          "name": "ACME Fantastic Fitness"
-      }
+      },
       {
-         "orgno": 987654322,
+         "businessIdentifier":{
+            "scheme":"business:NO:ORG",
+            "id":"987654322"
+         },
          "name": "ACME Candy and Ice Cream"
       }
    ]
@@ -123,24 +129,35 @@ Response:
 
 ```json
 {
-   "orgno": 987654321,
-   "name": "ACME Fantastic Fitness",
-   "isActive": true,
-   "createdAt": "2022-09-02T06:45:25.921251Z",
-   "updatedAt": "2023-03-27T13:50:21.750612Z",
-    "countryCode": "NO",
-   "businessAddress": {
-      "line1": "Robert Levins gate 5",
-      "locality": "OSLO",
-      "postalCode": "0154",
-      "countryCode": "NO"
+  "merchant": {
+    "businessidentifier": {
+      "scheme": "business:NO:ORG",
+      "id": "9876543221"
     },
-    "postalAddress": {
-      "line1": "Postboks 9236 Grønland",
-      "locality": "OSLO",
-      "postalCode": "0134",
-      "countryCode": "NO"
+    "name": "ACME Fantastic Fitness",
+    "status": "ACTIVE",
+    "createdAt": "2022-09-02T06:45:25.921251Z",
+    "updateddAt": "2022-09-02T06:45:25.921251Z",
+    "countryCode\"": "NO",
+    "businessAddress": {
+      "city": "Oslo",
+      "country": "NO",
+      "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "lines": [
+        "Robert Levins gate 5"
+      ],
+      "postCode": "0154"
+    },
+    "businesspostlAddress": {
+      "city": "Oslo",
+      "country": "NO",
+      "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "lines": [
+        "Robert Levins gate 5"
+      ],
+      "postCode": "0154"
     }
+  }
 }
 ```
 
@@ -183,12 +200,12 @@ Response:
 {
    "salesUnits":[
       {
-         "orgno": 123456,
-         "name": "ACME Fantastic Fitness HQ"
+         "msn": 123456,
+         "name": "ACME Fantastic Fitness"
       }
       {
-         "orgno": 654321,
-         "name": "ACME Fantastic Fitness Satellite 1"
+         "msn": 654321,
+         "name": "ACME Candy and Ice Cream"
       }
    ]
 }
@@ -213,12 +230,12 @@ Response:
 {
    "salesUnits":[
       {
-         "orgno": 123456,
-         "name": "ACME Fantastic Fitness HQ"
+         "msn": 123456,
+         "name": "ACME Fantastic Fitness"
       }
       {
-         "orgno": 654321,
-         "name": "ACME Fantastic Fitness Satellite 1"
+         "msn": 654321,
+         "name": "ACME Candy and Ice Cream"
       }
    ]
 }
@@ -328,7 +345,8 @@ Example `PATCH` request body:
 
 ```json
 {
-  "name": "ACME Fantastic Fitness DeLuxe",
+  "name": "ACME Fantastic Fitness Deluxe",
+  "salesUnitLogo": "VGhlIGltYWdlIGdvZXMgaGVyZQ==",
   "status": "ACTIVE"
 }
 ```

--- a/management-api-guide.md
+++ b/management-api-guide.md
@@ -385,7 +385,10 @@ Here is a sample request to
   },
   "salesUnitName": "ACME Fantastic Fitness",
   "salesUnitLogo": "VGhlIGltYWdlIGdvZXMgaGVyZQ==",
-  "settlementAccountNumber": "86011117947",
+    "settlementAccountNumber": {
+    "scheme": "BBAN:NO",
+    "id": "86011117947"
+  },
   "pricePackageId": "8a11afb7-c223-48ed-8ca6-4722b97261aa",
   "productType": "VIPPS_PA_NETT",
   "productUseCase": "WebsiteWithTest",

--- a/management-api-guide.md
+++ b/management-api-guide.md
@@ -23,7 +23,7 @@ We are implementing the most important functionality first, and these endpoints 
    An easy way to get a list of all the sales units that belong to the specified merchant.  
 3. [Get information about a sales unit](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-information-about-a-sales-unit):
    This endpoint is for retrieving details about one sales unit (MSN), such as
-   the name of the sales unit, the organization number is belongs to and the sales unit's configuration.
+   the name of the sales unit, the business identifier it belongs to and the sales unit's configuration.
 4. [Get the price packages for a partner](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-the-price-packages-for-a-partner):
    Lets a partner retrieve its price package details.
    The price packages are needed for pre-filling the product orders.
@@ -64,7 +64,7 @@ even without an integration in place.
 | -------- | ----------- | ------ |
 | Merchants: | | |
 | [`GET:/merchants`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getAllMerchants) | [Get all merchants](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-all-merchants). | 💡 Idea/proposal |
-| [`GET:/merchants/{businessIdentifier}`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchant) | [Get one merchant by organization number](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-one-merchant-by-organization-number). | 🟡 Available in Q3 |
+| [`GET:/merchants/{businessIdentifier}`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchant) | [Get one merchant by business identifier](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-one-merchant-by-business-identifier). | 🟡 Available in Q3 |
 | [`GET:/merchants/{businessIdentifier}/contracts`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchantContracts) | [Get a merchant's contract(s)](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-a-merchants-contracts). | 💡 Idea/proposal |
 | [`GET:/merchants/{businessIdentifier}/sales-units`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchantSalesUnits) | [Get the sales units for a merchant by business identifier](https://developer.vippsmobilepay.com/docs/APIs/management-api/management-api-guide/#get-the-sales-units-for-a-merchant-by-business-identifier). | ✅ Available |
 | Sales units: | | |
@@ -117,7 +117,7 @@ Response:
 If this endpoint is used with normal API keys (not partner keys), it will return just one merchant:
 The one making the API request.
 
-## Get one merchant by organization number
+## Get one merchant by business identifier
 
 Status: 🟡 Available in Q3.
 
@@ -469,7 +469,7 @@ When the submitted product order has been processed, an email is sent to both th
 partner/merchant making the request and the merchant that submitted the pre-filled product order.
 This will include information about:
 
-* The merchant's organization number
+* The merchant's business identifier
 * The merchant's name
 * The sales unit's MSN
 * The sales unit's name

--- a/management-api-guide.md
+++ b/management-api-guide.md
@@ -8,6 +8,11 @@ pagination_prev: null
 
 # API guide
 
+💥 IMPORTANT: We are making some changes to the API based on feedback.
+We have notified all users of the API on Slack about the ongoing changes.
+See the PR(s) for the latest news.
+Please contact us on Slack if you have questions. 💥
+
 The Management API lets partners and merchants manage their sales units, and allows for
 self-service for the most common tasks. Our goal is to let partners and merchants do
 as much as possible without needing assistance from us.

--- a/management-api-guide.md
+++ b/management-api-guide.md
@@ -393,7 +393,7 @@ Here is a sample request to
   "productType": "VIPPS_PA_NETT",
   "productUseCase": "WebsiteWithTest",
   "annualTurnover": 100000,
-  "intendedPurpose": "Gym membership for accessing the gym's facilities.\nGuest will be not physically present when buying the subscription,\nas that is done on the gym's website.",
+  "intendedPurpose": "Gym membership for accessing the gym's facilities. Guests will be not physically present when buying the subscription, as that is done on the gym's website.",
   "website": {
     "url": "https://example.com",
     "termsUrl": "https://example.com/terms-and-conditions",

--- a/management-api-quick-start.md
+++ b/management-api-quick-start.md
@@ -129,7 +129,7 @@ values={[
 Update the value for `business-identifier`.
 
 ```bash
-Send request Get merchant sales units by merchant ID
+Send request Get merchant sales units bybusiness identifier
 ```
 
 </TabItem>

--- a/management-api-quick-start.md
+++ b/management-api-quick-start.md
@@ -110,7 +110,7 @@ curl https://api.vipps.no/accessToken/get \
 
 The property `access_token` should be used for all other API requests in the `Authorization` header as the Bearer token.
 
-### Step 3 - Get merchant sales units by merchant ID
+### Step 3 - Get merchant sales units by business identifier
 
 Send request
 [`GET:v1/merchants/{orgno}/sales-units`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchantSalesUnits),

--- a/management-api-quick-start.md
+++ b/management-api-quick-start.md
@@ -110,12 +110,12 @@ curl https://api.vipps.no/accessToken/get \
 
 The property `access_token` should be used for all other API requests in the `Authorization` header as the Bearer token.
 
-### Step 3 - Get merchant sales units by organization number
+### Step 3 - Get merchant sales units by merchant ID
 
 Send request
 [`GET:v1/merchants/{orgno}/sales-units`](https://developer.vippsmobilepay.com/api/management/#tag/Merchants/operation/getMerchantSalesUnits),
-where `orgno` is the organization number of the sales unit.
-Details about the merchant will be provided.
+where `business-identifier` is the ID of the merchant.
+A list of ID numbers will be returned. These are the Merchant Serial Numbers for all the sales units associated with this merchant.
 
 <Tabs
 defaultValue="curl"
@@ -126,15 +126,17 @@ values={[
 ]}>
 <TabItem value="postman">
 
+Update the value for `business-identifier`.
+
 ```bash
-Send request Get merchant by organization number
+Send request Get merchant sales units by merchant ID
 ```
 
 </TabItem>
 <TabItem value="curl">
 
 ```bash
-curl https://api.vipps.no/management/v1/merchants/{ordno}/sales-units \
+curl https://api.vipps.no/management/v1/merchants/{business-identifier}/sales-units \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1Ni <truncated>" \
 -H "Ocp-Apim-Subscription-Key: 0f14ebcab0ec4b29ae0cb90d91b4a84a" \
@@ -148,7 +150,7 @@ curl https://api.vipps.no/management/v1/merchants/{ordno}/sales-units \
 </TabItem>
 </Tabs>
 
-Take note of the merchant serial numbers and use one of these in the next step.
+Take note of the ID numbers and use one of these in the next step.
 
 ### Step 4 - Get sales unit by Merchant Serial Number
 
@@ -170,7 +172,7 @@ values={[
 Send request Get sales unit details based on MSN
 ```
 
-If necessary, update `orgno` in the environment.
+If necessary, update `msn` in the environment.
 
 </TabItem>
 <TabItem value="curl">
@@ -189,7 +191,6 @@ curl https://api.vipps.no/management/v1/sales-units/{msn} \
 
 </TabItem>
 </Tabs>
-
 
 ## Next steps
 

--- a/management-api-quick-start.md
+++ b/management-api-quick-start.md
@@ -136,7 +136,7 @@ Send request Get merchant sales units bybusiness identifier
 <TabItem value="curl">
 
 ```bash
-curl https://api.vipps.no/management/v1/merchants/{business-identifier}/sales-units \
+curl https://api.vipps.no/management/v1/merchants/{scheme}/{id}/sales-units \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1Ni <truncated>" \
 -H "Ocp-Apim-Subscription-Key: 0f14ebcab0ec4b29ae0cb90d91b4a84a" \

--- a/tools/vipps-management-api-postman-collection.json
+++ b/tools/vipps-management-api-postman-collection.json
@@ -1,237 +1,243 @@
 {
-  "info": {
-    "_postman_id": "2f194f91-e912-4352-9900-eb61a941c5cd",
-    "name": "Management API - Collection",
-    "description": "The Vipps Management API lets partners, banks and large corporations manage\ntheir merchants (for example, submit product orders on behalf of their\nmerchants) and sales units.\nMore information: https://developer.vippsmobilepay.com/docs/APIs/partner-api/vipps-partner-api\n\n\nContact Support:\n Name: Vipps AS\n Email: developer@vippsmobilepay.com",
-    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
-  },
-  "item": [
-    {
-      "name": "Management API",
-      "item": [
-        {
-          "name": "Get merchant by organization number",
-          "request": {
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{access_token}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "method": "GET",
-            "header": [
-              {
-                "description": "(Required) Vipps Subscription Key",
-                "key": "Ocp-Apim-Subscription-Key",
-                "value": "{{Ocp-Apim-Subscription-Key}}"
-              },
-              {
-                "key": "Accept",
-                "value": "application/json;charset=UTF-8"
-              },
-              {
-                "key": "Merchant-Serial-Number",
-                "value": "{{merchantSerialNumber}}",
-                "type": "default"
-              },
-              {
-                "key": "Vipps-System-Name",
-                "value": "{{vipps_system_name}}",
-                "type": "default"
-              },
-              {
-                "key": "Vipps-System-Version",
-                "value": "{{vipps_system_version}}",
-                "type": "default"
-              },
-              {
-                "key": "Vipps-System-Plugin-Name",
-                "value": "{{vipps_system_plugin_name}}",
-                "type": "default"
-              },
-              {
-                "key": "Vipps-System-Plugin-Version",
-                "value": "{{vipps_system_plugin_version}}",
-                "type": "default"
-              }
-            ],
-            "url": {
-              "raw": "{{base_url_production}}/management/v1/merchants/:orgno/sales-units",
-              "host": [
-                "{{base_url_production}}"
-              ],
-              "path": [
-                "management",
-                "v1",
-                "merchants",
-                ":orgno",
-                "sales-units"
-              ],
-              "variable": [
-                {
-                  "key": "orgno",
-                  "value": "{{orgno}}",
-                  "description": "(Required) The Organization number for the merchant"
-                }
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Get sales unit details based on MSN",
-          "request": {
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{access_token}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "method": "GET",
-            "header": [
-              {
-                "description": "(Required) Vipps Subscription Key",
-                "key": "Ocp-Apim-Subscription-Key",
-                "value": "{{Ocp-Apim-Subscription-Key}}"
-              },
-              {
-                "key": "Accept",
-                "value": "application/json;charset=UTF-8"
-              },
-              {
-                "key": "Merchant-Serial-Number",
-                "value": "{{merchantSerialNumber}}",
-                "type": "default"
-              },
-              {
-                "key": "Vipps-System-Name",
-                "value": "{{vipps_system_name}}",
-                "type": "default"
-              },
-              {
-                "key": "Vipps-System-Version",
-                "value": "{{vipps_system_version}}",
-                "type": "default"
-              },
-              {
-                "key": "Vipps-System-Plugin-Name",
-                "value": "{{vipps_system_plugin_name}}",
-                "type": "default"
-              },
-              {
-                "key": "Vipps-System-Plugin-Version",
-                "value": "{{vipps_system_plugin_version}}",
-                "type": "default"
-              }
-            ],
-            "url": {
-              "raw": "{{base_url_production}}/management/v1/sales-units/:msn",
-              "host": [
-                "{{base_url_production}}"
-              ],
-              "path": [
-                "management",
-                "v1",
-                "sales-units",
-                ":msn"
-              ],
-              "variable": [
-                {
-                  "key": "msn",
-                  "value": "{{msn}}"
-                }
-              ]
-            }
-          },
-          "response": []
-        }
-      ]
-    },
-    {
-      "name": "Get Access Token",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.environment.set(\"access_token\", pm.response.json().access_token);"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "client_id",
-            "value": "{{client_id}}"
-          },
-          {
-            "key": "client_secret",
-            "value": "{{client_secret}}"
-          },
-          {
-            "key": "Ocp-Apim-Subscription-Key",
-            "value": "{{Ocp-Apim-Subscription-Key}}"
-          },
-          {
-            "key": "Merchant-Serial-Number",
-            "value": "{{merchantSerialNumber}}",
-            "type": "default"
-          },
-          {
-            "key": "Vipps-System-Name",
-            "value": "{{vipps_system_name}}",
-            "type": "default"
-          },
-          {
-            "key": "Vipps-System-Version",
-            "value": "{{vipps_system_version}}",
-            "type": "default"
-          },
-          {
-            "key": "Vipps-System-Plugin-Name",
-            "value": "{{vipps_system_plugin_name}}",
-            "type": "default"
-          },
-          {
-            "key": "Vipps-System-Plugin-Version",
-            "value": "{{vipps_system_plugin_version}}",
-            "type": "default"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": ""
-        },
-        "url": {
-          "raw": "{{base_url_production}}/accessToken/get",
-          "host": [
-            "{{base_url_production}}"
-          ],
-          "path": [
-            "accessToken",
-            "get"
-          ]
-        }
-      },
-      "response": []
-    }
-  ],
-  "variable": [
-    {
-      "key": "baseUrl",
-      "value": "https://api.vipps.no/partner-api",
-      "type": "string"
-    }
-  ]
+	"info": {
+		"_postman_id": "fcb60588-b6b4-4570-8e78-90dd9cdf4cff",
+		"name": "Management API - Collection",
+		"description": "The Vipps Management API lets partners, banks and large corporations manage\ntheir merchants (for example, submit product orders on behalf of their\nmerchants) and sales units.\nMore information: https://developer.vippsmobilepay.com/docs/APIs/partner-api/vipps-partner-api\n\n\nContact Support:\n Name: Vipps AS\n Email: developer@vippsmobilepay.com",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Management API",
+			"item": [
+				{
+					"name": "Get merchant sales units by merchant ID",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"description": "(Required) Vipps Subscription Key",
+								"key": "Ocp-Apim-Subscription-Key",
+								"value": "{{Ocp-Apim-Subscription-Key}}"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json;charset=UTF-8"
+							},
+							{
+								"key": "Merchant-Serial-Number",
+								"value": "{{merchantSerialNumber}}",
+								"type": "default"
+							},
+							{
+								"key": "Vipps-System-Name",
+								"value": "{{vipps_system_name}}",
+								"type": "default"
+							},
+							{
+								"key": "Vipps-System-Version",
+								"value": "{{vipps_system_version}}",
+								"type": "default"
+							},
+							{
+								"key": "Vipps-System-Plugin-Name",
+								"value": "{{vipps_system_plugin_name}}",
+								"type": "default"
+							},
+							{
+								"key": "Vipps-System-Plugin-Version",
+								"value": "{{vipps_system_plugin_version}}",
+								"type": "default"
+							}
+						],
+						"url": {
+							"raw": "{{base_url_production}}/management/v1/merchants/:business-identifier/sales-units",
+							"host": [
+								"{{base_url_production}}"
+							],
+							"path": [
+								"management",
+								"v1",
+								"merchants",
+								":business-identifier",
+								"sales-units"
+							],
+							"query": [
+								{
+									"key": "",
+									"value": "",
+									"disabled": true
+								}
+							],
+							"variable": [
+								{
+									"key": "business-identifier",
+									"value": "{{orgno}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get sales unit details based on MSN",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"description": "(Required) Vipps Subscription Key",
+								"key": "Ocp-Apim-Subscription-Key",
+								"value": "{{Ocp-Apim-Subscription-Key}}"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json;charset=UTF-8"
+							},
+							{
+								"key": "Merchant-Serial-Number",
+								"value": "{{merchantSerialNumber}}",
+								"type": "default"
+							},
+							{
+								"key": "Vipps-System-Name",
+								"value": "{{vipps_system_name}}",
+								"type": "default"
+							},
+							{
+								"key": "Vipps-System-Version",
+								"value": "{{vipps_system_version}}",
+								"type": "default"
+							},
+							{
+								"key": "Vipps-System-Plugin-Name",
+								"value": "{{vipps_system_plugin_name}}",
+								"type": "default"
+							},
+							{
+								"key": "Vipps-System-Plugin-Version",
+								"value": "{{vipps_system_plugin_version}}",
+								"type": "default"
+							}
+						],
+						"url": {
+							"raw": "{{base_url_production}}/management/v1/sales-units/:msn",
+							"host": [
+								"{{base_url_production}}"
+							],
+							"path": [
+								"management",
+								"v1",
+								"sales-units",
+								":msn"
+							],
+							"variable": [
+								{
+									"key": "msn",
+									"value": "{{msn}}"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Get Access Token",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.environment.set(\"access_token\", pm.response.json().access_token);"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "client_id",
+						"value": "{{client_id}}"
+					},
+					{
+						"key": "client_secret",
+						"value": "{{client_secret}}"
+					},
+					{
+						"key": "Ocp-Apim-Subscription-Key",
+						"value": "{{Ocp-Apim-Subscription-Key}}"
+					},
+					{
+						"key": "Merchant-Serial-Number",
+						"value": "{{merchantSerialNumber}}",
+						"type": "default"
+					},
+					{
+						"key": "Vipps-System-Name",
+						"value": "{{vipps_system_name}}",
+						"type": "default"
+					},
+					{
+						"key": "Vipps-System-Version",
+						"value": "{{vipps_system_version}}",
+						"type": "default"
+					},
+					{
+						"key": "Vipps-System-Plugin-Name",
+						"value": "{{vipps_system_plugin_name}}",
+						"type": "default"
+					},
+					{
+						"key": "Vipps-System-Plugin-Version",
+						"value": "{{vipps_system_plugin_version}}",
+						"type": "default"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{base_url_production}}/accessToken/get",
+					"host": [
+						"{{base_url_production}}"
+					],
+					"path": [
+						"accessToken",
+						"get"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"variable": [
+		{
+			"key": "baseUrl",
+			"value": "https://api.vipps.no/partner-api",
+			"type": "string"
+		}
+	]
 }


### PR DESCRIPTION
We can not use just `orgno` when going international. Based on our internal RFC for external ids we will use both `scheme` and `id` in URI paths to identify businesses, and use this JSON representation:
```
"businessidentifier": {
  "scheme": "business:NO:ORG",
  "id": "9876543221"
},
```